### PR TITLE
192 gateway add routes for ranking live remove swagger

### DIFF
--- a/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
+++ b/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
@@ -33,17 +33,6 @@
         "Match": {
           "Path": "/bot/{*any}"
         }
-      },
-      "botswaggerRoute": {
-        "ClusterId": "botcluster",
-        "Match": {
-          "Path": "/bot/swagger/{*any}"
-        },
-        "Transforms": [
-          {
-            "PathRemovePrefix": "/bot"
-          }
-        ]
       }
     },
     "Clusters": {

--- a/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
+++ b/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
@@ -21,17 +21,6 @@
           "Path": "/games/{*any}"
         }
       },
-      "gamesSwaggerRoute": {
-        "ClusterId": "gamesapicluster",
-        "Match": {
-          "Path": "/games/swagger/{*any}"
-        },
-        "Transforms": [
-          {
-            "PathRemovePrefix": "/games"
-          }
-        ]
-      },
       "rankingRoute": {
         "ClusterId": "rankingcluster",
         "Match": {

--- a/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
+++ b/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
@@ -38,6 +38,10 @@
         "ClusterId": "livecluster",
         "Match": {
           "Path": "/live/{*any}"
+        },
+        "Transforms": [
+          {
+            "PathRemovePrefix": "/live"
         }
       }
     },

--- a/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
+++ b/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
@@ -33,6 +33,12 @@
         "Match": {
           "Path": "/bot/{*any}"
         }
+      },
+      "liveRoute": {
+        "ClusterId": "livecluster",
+        "Match": {
+          "Path": "/live/{*any}"
+        }
       }
     },
     "Clusters": {

--- a/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
+++ b/src/services/gateway/Codebreaker.ApiGateway/appsettings.json
@@ -42,7 +42,19 @@
         "Transforms": [
           {
             "PathRemovePrefix": "/live"
-        }
+          }
+        ]
+      },
+      "usersRoute": {
+        "ClusterId": "userscluster",
+        "Match": {
+          "Path": "/users/{*any}"
+        },
+        "Transforms": [
+          {
+            "PathRemovePrefix": "/users"
+          }
+        ]
       }
     },
     "Clusters": {
@@ -71,6 +83,13 @@
         "Destinations": {
           "rankingcluster/destination1": {
             "Address": "https://ranking"
+          }
+        }
+      },
+      "userscluster": {
+        "Destinations": {
+          "userscluster/destination1": {
+            "Address": "https://users"
           }
         }
       }

--- a/src/services/host/Codebreaker.AppHost/Program.cs
+++ b/src/services/host/Codebreaker.AppHost/Program.cs
@@ -68,7 +68,6 @@ else
         .AddDatabase("codebreaker");
 
     var gameAPIs = builder.AddProject<Projects.Codebreaker_GameAPIs>("gameapis")
-        .WithExternalHttpEndpoints()
         .WithReference(cosmos)
         .WithReference(redis)
         .WithReference(insights)
@@ -84,20 +83,17 @@ else
         .WithEnvironment("Bot__Delay", botDelay);
 
     var live = builder.AddProject<Projects.Codebreaker_Live>("live")
-        .WithExternalHttpEndpoints()
         .WithReference(insights)
         .WithReference(eventHub)
         .WithReference(signalR);
 
     var ranking = builder.AddProject<Projects.Codebreaker_Ranking>("ranking")
-        .WithExternalHttpEndpoints()
         .WithReference(cosmos)
         .WithReference(insights)
         .WithReference(eventHub)
         .WithReference(blob);
 
     var users = builder.AddProject<Projects.CodeBreaker_UserService>("users")
-        .WithExternalHttpEndpoints()
         .WithReference(insights);
 
     var gateway = builder.AddProject<Projects.Codebreaker_ApiGateway>("gateway")


### PR DESCRIPTION
- Removed swagger routes from gateway
- Add routes for live-service and user-service
- Removed external http endpoint from gameapis, live, ranking and `users` services to make them only accessible by the `gateway` service.