### PR TITLE
Conditionally configure reverse proxy in non-prod environments

### DIFF
--- a/src/services/gateway/Codebreaker.ApiGateway/Program.cs
+++ b/src/services/gateway/Codebreaker.ApiGateway/Program.cs
@@ -75,10 +75,13 @@ builder.Services.AddCors(setup => setup.AddDefaultPolicy(policy => policy.AllowA
 
 builder.AddServiceDefaults();
 
-builder.Services.AddReverseProxy()
-    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
-    .AddServiceDiscoveryDestinationResolver();
+var reverseProxyBuilder = builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 
+if (!builder.Environment.IsProduction())
+{ 
+    reverseProxyBuilder.AddServiceDiscoveryDestinationResolver();
+}
 
 // builder.Services.AddRazorPages(); // authentication UI in Views
 


### PR DESCRIPTION
The reverse proxy configuration now conditionally includes the AddServiceDiscoveryDestinationResolver method only if the application is not running in a production environment. 
https://github.com/dotnet/aspire/issues/4605