### PR TITLE
Updated github action for setting DOTNET_ENVIRONMENT to Staging for blazor application in rg-codebreakertest

### DIFF
--- a/.github/workflows/codebreaker-azure.yml
+++ b/.github/workflows/codebreaker-azure.yml
@@ -72,6 +72,19 @@ jobs:
     with:
      AZURE_ENV_NAME: codebreakertest
 
+  set-blazor-staging-environmentvariable:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Azure Login
+      uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    - name: Update DOTNET_ENVIRONMENT for the Blazor containerapp to Staging
+      uses: azure/cli@v2
+      with:
+        azcliversion: latest
+        inlineScript: az containerapp update -n blazor -g rg-codebreakertest --set-env-vars DOTNET_ENVIRONMENT=Staging
+
   deploy-prod:
     uses: ./.github/workflows/deploy.yml
     secrets: inherit

--- a/.github/workflows/codebreaker-azure.yml
+++ b/.github/workflows/codebreaker-azure.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Azure Login
       uses: azure/login@v2
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+        creds: ${{ secrets.AZURE_CREDENTIALS_TESTENV }}
     - name: Update DOTNET_ENVIRONMENT for the Blazor containerapp to Staging
       uses: azure/cli@v2
       with:


### PR DESCRIPTION
@christiannagel What do you think about that?

Note: I cannot check if the secret _AZURE_CREDENTIALS_ is present in this repository, due to missing permissions.


This PR is related to [Issue 110](https://github.com/CodebreakerApp/Codebreaker.Blazor/issues/110) and [PR 111](https://github.com/CodebreakerApp/Codebreaker.Blazor/pull/111) in the Codebreaker.Blazor repository.