### PR TITLE
Update Analyzer Package

### DIFF
--- a/.github/workflows/codebreaker-lib-analyzers-stable.yml
+++ b/.github/workflows/codebreaker-lib-analyzers-stable.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with: 
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Build the library
         run: dotnet build -c Release ${{ env.solutionfile-path }}

--- a/.github/workflows/codebreaker-lib-analyzers.yml
+++ b/.github/workflows/codebreaker-lib-analyzers.yml
@@ -25,7 +25,7 @@ jobs:
       version-offset: 38
       solutionfile-path: src/Codebreaker.Analyzers.slnx
       projectfile-path: src/services/common/Codebreaker.GameAPIs.Analyzers/Codebreaker.Analyzers.csproj
-      dotnet-version: '9.0.x'
+      dotnet-version: '10.0.x'
       artifact-name: codebreaker-analyzers
       branch-name: main
 

--- a/.github/workflows/codebreaker-lib-backendmodels-stable.yml
+++ b/.github/workflows/codebreaker-lib-backendmodels-stable.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with: 
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Build the library
         run: dotnet build -c Release ${{ env.solutionfile-path }}

--- a/.github/workflows/codebreaker-lib-backendmodels.yml
+++ b/.github/workflows/codebreaker-lib-backendmodels.yml
@@ -25,7 +25,7 @@ jobs:
       version-offset: 10
       solutionfile-path: src/Codebreaker.Backend.Models.sln
       projectfile-path: src/services/common/Codebreaker.GameAPIs.Models/Codebreaker.GameAPIs.Models.csproj
-      dotnet-version: '9.0.x'
+      dotnet-version: '10.0.x'
       artifact-name: codebreaker-backend-models
       branch-name: main
 

--- a/.github/workflows/codebreaker-lib-client-stable.yml
+++ b/.github/workflows/codebreaker-lib-client-stable.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with: 
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Build the library
         run: dotnet build -c Release ${{ env.solutionfile-path }}

--- a/.github/workflows/codebreaker-lib-client.yml
+++ b/.github/workflows/codebreaker-lib-client.yml
@@ -25,7 +25,7 @@ jobs:
       version-offset: 10
       solutionfile-path: src/Codebreaker.GameAPIs.Client.slnx
       projectfile-path: src/clients/Codebreaker.GameAPIs.Client/Codebreaker.GameAPIs.Client.csproj
-      dotnet-version: '9.0.x'
+      dotnet-version: '10.0.x'
       artifact-name: codebreaker-clientlib
       branch-name: main
 

--- a/.github/workflows/codebreaker-lib-cosmos-stable.yml
+++ b/.github/workflows/codebreaker-lib-cosmos-stable.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with: 
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Build the library
         run: dotnet build -c Release ${{ env.solutionfile-path }}

--- a/.github/workflows/codebreaker-lib-cosmos.yml
+++ b/.github/workflows/codebreaker-lib-cosmos.yml
@@ -25,7 +25,7 @@ jobs:
       version-offset: 10
       solutionfile-path: src/Codebreaker.Backend.Cosmos.sln
       projectfile-path: src/services/common/Codebreaker.Data.Cosmos/Codebreaker.Data.Cosmos.csproj
-      dotnet-version: '9.0.x'
+      dotnet-version: '10.0.x'
       artifact-name: codebreaker-cosmos
       branch-name: main
 

--- a/.github/workflows/codebreaker-lib-postgresql.yml
+++ b/.github/workflows/codebreaker-lib-postgresql.yml
@@ -24,7 +24,7 @@ jobs:
       version-offset: 5
       solutionfile-path: src/Codebreaker.Backend.Postgres.slnx
       projectfile-path: src/services/common/Codebreaker.Data.Postgres/Codebreaker.Data.Postgres.csproj
-      dotnet-version: '9.0.x'
+      dotnet-version: '10.0.x'
       artifact-name: codebreaker-postgres
       branch-name: main
 

--- a/.github/workflows/codebreaker-lib-sqlserver-stable.yml
+++ b/.github/workflows/codebreaker-lib-sqlserver-stable.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with: 
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Build the library
         run: dotnet build -c Release ${{ env.solutionfile-path }}

--- a/.github/workflows/codebreaker-lib-sqlserver.yml
+++ b/.github/workflows/codebreaker-lib-sqlserver.yml
@@ -24,7 +24,7 @@ jobs:
       version-offset: 10
       solutionfile-path: src/Codebreaker.Backend.SqlServer.slnx
       projectfile-path: src/services/common/Codebreaker.Data.SqlServer/Codebreaker.Data.SqlServer.csproj
-      dotnet-version: '9.0.x'
+      dotnet-version: '10.0.x'
       artifact-name: codebreaker-sqlserver
       branch-name: main
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -136,6 +136,6 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.analyzers" Version="1.21.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -65,12 +65,15 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.32.0" />
     <!-- Entity Framework packages (conditional versions) -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.11" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="9.0.9" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="8.0.26" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="9.0.15" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.15" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.15" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
     <!-- Microsoft Extensions packages -->
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9" />
@@ -78,17 +81,20 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.15" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.3" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.9" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.15" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.15" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.5.0" />
     <!-- Microsoft UI and Identity packages -->
@@ -112,6 +118,7 @@
     <!-- PostgreSQL packages (conditional versions) -->
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />  
     <!-- OpenTelemetry packages -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.10.0-beta.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="CNinnovation.Codebreaker.GamesClient" Version="3.8.0" />
     <PackageVersion Include="CNinnovation.Codebreaker.SqlServer" Version="3.8.0" />
     <!-- Test and utility packages -->
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.32.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
@@ -100,7 +100,7 @@
     <PackageVersion Include="Microsoft.Identity.Web.DownstreamApi" Version="3.14.1" />
     <PackageVersion Include="Microsoft.Identity.Web.UI" Version="3.14.1" />
     <!-- Testing packages -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.55.0" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.55.0" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="1.7.0" />

--- a/src/services/common/Codebreaker.GameAPIs.Analyzers.Tests/Codebreaker.GameAPIs.Analyzers.Tests.csproj
+++ b/src/services/common/Codebreaker.GameAPIs.Analyzers.Tests/Codebreaker.GameAPIs.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/services/common/Codebreaker.GameAPIs.Analyzers/Codebreaker.Analyzers.csproj
+++ b/src/services/common/Codebreaker.GameAPIs.Analyzers/Codebreaker.Analyzers.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <PackageId>CNinnovation.Codebreaker.Analyzers</PackageId>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>13.0</LangVersion>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
     <PackageTags>
       Codebreaker;CNinnovation;GameAnalyzers
     </PackageTags>

--- a/src/services/common/Codebreaker.GameAPIs.Models.Tests/Codebreaker.GameAPIs.Models.Tests.csproj
+++ b/src/services/common/Codebreaker.GameAPIs.Models.Tests/Codebreaker.GameAPIs.Models.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/services/common/Codebreaker.GameAPIs.Models/Codebreaker.GameAPIs.Models.csproj
+++ b/src/services/common/Codebreaker.GameAPIs.Models/Codebreaker.GameAPIs.Models.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>CNinnovation.Codebreaker.BackendModels</PackageId>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageTags>
@@ -15,7 +15,7 @@
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageIcon>codebreaker.jpeg</PackageIcon>
     <IsAotCompatible>true</IsAotCompatible>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### PR Classification
This pull request adds .NET 10 support, updates dependencies, and increments package versions for a new release.

#### PR Summary
The codebase is updated to support .NET 10, with corresponding changes to project files, CI workflows, and dependency versions.
- All GitHub Actions workflow YAML files now use `dotnet-version: 10.0.x`.
- `Codebreaker.Analyzers.csproj` and `Codebreaker.GameAPIs.Models.csproj` target `net10.0` in addition to previous frameworks.
- `Codebreaker.GameAPIs.Models.Tests.csproj` now targets `net10.0`.
- `Directory.Build.props` and project files incremented version from 3.8.0 to 3.9.0.
- `Directory.Packages.props` updates key dependencies and adds support for `net10.0` package versions.
