### PR TITLE
Backend models: Update workflow to use .slnx and bump Analyzers to 3.9.0

### DIFF
--- a/.github/workflows/codebreaker-lib-backendmodels.yml
+++ b/.github/workflows/codebreaker-lib-backendmodels.yml
@@ -23,7 +23,7 @@ jobs:
       version-suffix: preview.1.
       version-number: ${{ github.run_number }}
       version-offset: 10
-      solutionfile-path: src/Codebreaker.Backend.Models.sln
+      solutionfile-path: src/Codebreaker.Backend.Models.slnx
       projectfile-path: src/services/common/Codebreaker.GameAPIs.Models/Codebreaker.GameAPIs.Models.csproj
       dotnet-version: '10.0.x'
       artifact-name: codebreaker-backend-models

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.0" />
     <PackageVersion Include="BlazorApplicationInsights" Version="3.2.1" />
     <!-- Codebreaker packages -->
-    <PackageVersion Include="CNinnovation.Codebreaker.Analyzers" Version="3.8.0" />
+    <PackageVersion Include="CNinnovation.Codebreaker.Analyzers" Version="3.9.0" />
     <PackageVersion Include="CNinnovation.Codebreaker.BackendModels" Version="3.8.0" />
     <PackageVersion Include="CNinnovation.Codebreaker.Cosmos" Version="3.8.0" />
     <PackageVersion Include="CNinnovation.Codebreaker.GamesClient" Version="3.8.0" />


### PR DESCRIPTION
Update workflow to use .slnx and bump Analyzers to 3.9.0

Switched codebreaker-lib-backendmodels.yml to use the .slnx solution file for builds. Updated CNinnovation.Codebreaker.Analyzers package version to 3.9.0 in central package management.