### PR TITLE
data libraries - .NET 10

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,8 +35,8 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.0" />
     <PackageVersion Include="BlazorApplicationInsights" Version="3.2.1" />
     <!-- Codebreaker packages -->
-    <PackageVersion Include="CNinnovation.Codebreaker.Analyzers" Version="3.8.0" />
-    <PackageVersion Include="CNinnovation.Codebreaker.BackendModels" Version="3.8.0" />
+    <PackageVersion Include="CNinnovation.Codebreaker.Analyzers" Version="3.9.0" />
+    <PackageVersion Include="CNinnovation.Codebreaker.BackendModels" Version="3.9.0" />
     <PackageVersion Include="CNinnovation.Codebreaker.Cosmos" Version="3.8.0" />
     <PackageVersion Include="CNinnovation.Codebreaker.GamesClient" Version="3.8.0" />
     <PackageVersion Include="CNinnovation.Codebreaker.SqlServer" Version="3.8.0" />

--- a/src/services/common/Codebreaker.Data.Cosmos/Codebreaker.Data.Cosmos.csproj
+++ b/src/services/common/Codebreaker.Data.Cosmos/Codebreaker.Data.Cosmos.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>CNinnovation.Codebreaker.Cosmos</PackageId>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageTags>
@@ -14,12 +14,12 @@
     </Description>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageIcon>codebreaker.jpeg</PackageIcon>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CNinnovation.Codebreaker.BackendModels" Version="3.8.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" Version="9.0.0" />
+    <PackageReference Include="CNinnovation.Codebreaker.BackendModels" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Cosmos" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/services/common/Codebreaker.Data.Postgres/Codebreaker.Data.Postgres.csproj
+++ b/src/services/common/Codebreaker.Data.Postgres/Codebreaker.Data.Postgres.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>CNinnovation.Codebreaker.Postgres</PackageId>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -15,20 +15,13 @@
     </Description>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageIcon>codebreaker.jpeg</PackageIcon>
-    <VersionPrefix>3.8.0</VersionPrefix>
+    <VersionPrefix>3.9.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CNinnovation.Codebreaker.BackendModels" Version="3.8.0" />
+    <PackageReference Include="CNinnovation.Codebreaker.BackendModels" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />	
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-	  <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-	</ItemGroup>
 
   <ItemGroup>
     <None Include="docs/readme.md" Pack="true" PackagePath="\" />

--- a/src/services/common/Codebreaker.Data.Postgres/Directory.Packages.props
+++ b/src/services/common/Codebreaker.Data.Postgres/Directory.Packages.props
@@ -1,8 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- Enable central package management, https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management -->
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-  </ItemGroup>
-</Project>

--- a/src/services/common/Codebreaker.Data.SqlServer.Tests/Codebreaker.Data.SqlServer.Tests.csproj
+++ b/src/services/common/Codebreaker.Data.SqlServer.Tests/Codebreaker.Data.SqlServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,16 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/services/common/Codebreaker.Data.SqlServer/Codebreaker.Data.SqlServer.csproj
+++ b/src/services/common/Codebreaker.Data.SqlServer/Codebreaker.Data.SqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>CNinnovation.Codebreaker.SqlServer</PackageId>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -15,12 +15,12 @@
     </Description>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageIcon>codebreaker.jpeg</PackageIcon>
-    <Version>3.8.0</Version>
+    <Version>3.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CNinnovation.Codebreaker.BackendModels" Version="3.8.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+    <PackageReference Include="CNinnovation.Codebreaker.BackendModels" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### PR Classification
This pull request updates package versions, expands target frameworks, and streamlines package management for data access libraries.

#### PR Summary
The PR upgrades Codebreaker data libraries to support .NET 10, updates internal package versions, and consolidates package references for improved maintainability.
- Directory.Packages.props: Bumps CNinnovation.Codebreaker.Analyzers and BackendModels to 3.9.0.
- Codebreaker.Data.Cosmos.csproj, Codebreaker.Data.Postgres.csproj, Codebreaker.Data.SqlServer.csproj: Add net10.0 target, remove explicit package versions, increment package versions to 3.9.0.
- Codebreaker.Data.Postgres.csproj: Removes conditional Npgsql references in favor of a single, versionless reference.
- Codebreaker.Data.SqlServer.Tests.csproj: Removes explicit test package versions and adds xunit.v3.
