### PR TITLE
client lib: update test infra, add net10.0, and clean up references

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -109,8 +109,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.55.0" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.55.0" />
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="1.7.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.0" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NUnit" Version="4.4.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.10.0" />
@@ -133,8 +133,7 @@
     <PackageVersion Include="System.Text.Json" Version="9.0.9" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- xUnit packages -->
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.analyzers" Version="1.21.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>

--- a/src/clients/Codebreaker.GameAPIs.Client.Tests/Codebreaker.GameAPIs.Client.Tests.csproj
+++ b/src/clients/Codebreaker.GameAPIs.Client.Tests/Codebreaker.GameAPIs.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 		<OutputType>Exe</OutputType>

--- a/src/clients/Codebreaker.GameAPIs.Client/Codebreaker.GameAPIs.Client.csproj
+++ b/src/clients/Codebreaker.GameAPIs.Client/Codebreaker.GameAPIs.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>CNinnovation.Codebreaker.GamesClient</PackageId>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -16,7 +16,6 @@
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <PackageIcon>codebreaker.jpeg</PackageIcon>
 	  <Version>3.9.0</Version>
-		<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
@@ -25,13 +24,8 @@
     <None Include="Images/codebreaker.jpeg" Pack="true" PackagePath="\" />
   </ItemGroup>
 
-  <!-- Not forcing a .NET 8 client who reference this package to use a newer Microsoft.Extensions.Logging.Abstractions library -->
-  <ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-  </ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update test infra, add net10.0, and clean up references

- Bump Microsoft.Testing.Platform and TrxReport to 2.2.1
- Update xunit.analyzers to 1.27.0 and remove explicit xunit version
- Change test project to target only net10.0
- Add net10.0 to client library target frameworks
- Remove ManagePackageVersionsCentrally property
- Simplify Microsoft.Extensions.Logging.Abstractions reference to use central management